### PR TITLE
Set correct startup args

### DIFF
--- a/src/CodeConnect.Touch/CodeConnect.Touch.csproj
+++ b/src/CodeConnect.Touch/CodeConnect.Touch.csproj
@@ -33,6 +33,8 @@
     <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Just set the startup arguments and program in the `.csproj`.

I also opened an issue for VS extensions so we hopefully won't need to do this in the future. 

See: Microsoft/extendvs/issues/25
