### PR TITLE
Interpolates the geometry string in invariant culture

### DIFF
--- a/src/CodeConnect.Touch/CodeConnect.Touch.csproj
+++ b/src/CodeConnect.Touch/CodeConnect.Touch.csproj
@@ -7,6 +7,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <UseCodebase>true</UseCodebase>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>
@@ -26,7 +27,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CodeConnect.Touch</RootNamespace>
     <AssemblyName>CodeConnect.Touch</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>

--- a/src/CodeConnect.Touch/Helpers/TouchControlShapeFactory.cs
+++ b/src/CodeConnect.Touch/Helpers/TouchControlShapeFactory.cs
@@ -27,7 +27,7 @@ namespace CodeConnect.Touch.Helpers
             var point2 = ToCartesian(endAngle, OUTER_RADIUS);
             var point3 = ToCartesian(endAngle, INNER_RADIUS);
             var point4 = ToCartesian(startAngle, INNER_RADIUS);
-            var pathDefinition = $"M {point1.X} {point1.Y} A {OUTER_RADIUS} {OUTER_RADIUS} 0 0 1 {point2.X} {point2.Y} L {point3.X} {point3.Y} A {INNER_RADIUS} {INNER_RADIUS} 0 0 0 {point4.X} {point4.Y} z";
+            var pathDefinition = formatInvariant($"M {point1.X} {point1.Y} A {OUTER_RADIUS} {OUTER_RADIUS} 0 0 1 {point2.X} {point2.Y} L {point3.X} {point3.Y} A {INNER_RADIUS} {INNER_RADIUS} 0 0 0 {point4.X} {point4.Y} z");
             var geometry = Geometry.Parse(pathDefinition); 
             return geometry;
         }
@@ -55,6 +55,19 @@ namespace CodeConnect.Touch.Helpers
             {
 
             };
+        }
+
+        /// <summary>
+        /// Interpolates the string in invariant culture
+        /// 
+        /// Note: this is the only method that requires .NET framework 4.6
+        /// If we ever need to drop to 4.5, we'll just format the string the old way.
+        /// </summary>
+        /// <param name="format"></param>
+        /// <returns></returns>
+        private static string formatInvariant(IFormattable format)
+        {
+            return format.ToString(null, System.Globalization.CultureInfo.InvariantCulture);
         }
     }
 }


### PR DESCRIPTION
Interpolates the geometry string in invariant culture. This closes #5.
This requires the project to target .NET 4.6, and if we need to go back to 4.5, we can format strings the old way or use [StringInterpolationBridge](https://www.nuget.org/packages/StringInterpolationBridge). [More info](https://stackoverflow.com/questions/32076823/string-interpolation-in-visual-studio-2015-and-iformatprovider-ca1305)
